### PR TITLE
[#72] Integrate literal syntax for date/time formats

### DIFF
--- a/core/shared/src/main/scala/kantan/regex/literals/RegexLiteral.scala
+++ b/core/shared/src/main/scala/kantan/regex/literals/RegexLiteral.scala
@@ -18,26 +18,17 @@ package kantan.regex
 package literals
 
 import contextual._
-import java.util.regex.{Pattern, PatternSyntaxException}
+import java.util.regex.Pattern
 
-@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
-object RegexLiteral extends Interpolator {
-  type Output = Pattern
-  def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = {
-    interpolation.parts.foreach {
-      case lit @ Literal(_, _) ⇒
-        try Pattern.compile(interpolation.literals.head)
-        catch {
-          case p: PatternSyntaxException ⇒
-            // We take only the interesting part of the error message
-            val message = p.getMessage.split(" near").head
-            interpolation.error(lit, p.getIndex - 1, message)
-        }
-      case hole @ Hole(_, _) ⇒
-        interpolation.abort(hole, "substitution is not supported")
+object RegexLiteral extends Verifier[Pattern] {
+
+  override def check(string: String): Either[(Int, String), Pattern] =
+    // We could do a better job at analysing the error message and extracting the interesting bits, but:
+    // - this is not guaranteed to always work - error message might change format
+    // - it doesn't work with scala.js, and I'm not interested in this enough to have different error handling depending
+    //   on the target platform.
+    try { Right(Pattern.compile(string)) } catch {
+      case e: Exception ⇒ Left((0, e.getMessage))
     }
-    Nil
-  }
 
-  def evaluate(interpolation: RuntimeInterpolation): Pattern = Pattern.compile(interpolation.parts.mkString)
 }

--- a/docs/src/main/tut/java8.md
+++ b/docs/src/main/tut/java8.md
@@ -60,6 +60,19 @@ And we can now simply write:
 input.evalRegex[LocalDate](rx"\[(\d\d/\d\d/\d\d\d\d)\]", 1).foreach(println _)
 ```
 
+Note that while you can pass a [`DateTimeFormatter`] directly, the preferred way of dealing with pattern strings is to
+use the literal syntax provided by kantan.regex:
+
+```tut:silent
+localDateDecoder(fmt"dd-MM-yyyy")
+```
+
+The advantage is that this is checked at compile time - invalid pattern strings will cause a compilation error:
+
+```tut:fail
+localDateDecoder(fmt"FOOBAR")
+```
+
 [`GroupDecoder`]:{{ site.baseurl }}/api/kantan/regex/package$$GroupDecoder.html
 [`Instant`]:https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html
 [`LocalDateTime`]:https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html
@@ -67,3 +80,4 @@ input.evalRegex[LocalDate](rx"\[(\d\d/\d\d/\d\d\d\d)\]", 1).foreach(println _)
 [`ZonedDateTime`]:https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html
 [`LocalDate`]:https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html
 [`LocalTime`]:https://docs.oracle.com/javase/8/docs/api/java/time/LocalTime.html
+[`DateTimeFormatter`]:https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html

--- a/docs/src/main/tut/joda.md
+++ b/docs/src/main/tut/joda.md
@@ -60,7 +60,18 @@ And we're done, as far as decoding is concerned. We only need to get a regular e
 input.evalRegex[org.joda.time.LocalDate](rx"\[(\d\d-\d\d-\d\d\d\d)\]", 1).foreach(println _)
 ```
 
+Note that while you can pass a [`DateTimeFormatter`] directly, the preferred way of dealing with pattern strings is to
+use the literal syntax provided by kantan.regex:
 
+```tut:silent
+localDateDecoder(fmt"dd-MM-yyyy")
+```
+
+The advantage is that this is checked at compile time - invalid pattern strings will cause a compilation error:
+
+```tut:fail
+localDateDecoder(fmt"FOOBAR")
+```
 
 [`Date`]:https://docs.oracle.com/javase/7/docs/api/java/util/Date.html
 [`DateTime`]:http://joda-time.sourceforge.net/apidocs/org/joda/time/DateTime.html
@@ -69,3 +80,4 @@ input.evalRegex[org.joda.time.LocalDate](rx"\[(\d\d-\d\d-\d\d\d\d)\]", 1).foreac
 [`LocalTime`]:http://joda-time.sourceforge.net/apidocs/org/joda/time/LocalTime.html
 [`DateTimeFormat`]:http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html
 [`GroupDecoder`]:{{ site.baseurl }}/api/kantan/regex/package$$GroupDecoder.html
+[`DateTimeFormatter`]:http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormatter.html

--- a/java8/src/main/scala/kantan/regex/java8/package.scala
+++ b/java8/src/main/scala/kantan/regex/java8/package.scala
@@ -19,7 +19,7 @@ package kantan.regex
 import java.time._
 import kantan.codecs.export.Exported
 import kantan.codecs.strings.StringDecoder
-import kantan.codecs.strings.java8.TimeDecoderCompanion
+import kantan.codecs.strings.java8.{TimeDecoderCompanion, ToFormatLiteral}
 
 /** Declares [[kantan.regex.GroupDecoder]] instances for java8 date and time types.
   *
@@ -28,7 +28,7 @@ import kantan.codecs.strings.java8.TimeDecoderCompanion
   * brings both the instance creation and default instances in scope. Without this type trickery, custom instances
   * and default ones would always clash.
   */
-package object java8 extends TimeDecoderCompanion[Option[String], DecodeError, codecs.type] {
+package object java8 extends TimeDecoderCompanion[Option[String], DecodeError, codecs.type] with ToFormatLiteral {
 
   override def decoderFrom[D](d: StringDecoder[D]) = codecs.fromString(d)
 

--- a/joda-time/src/main/scala/kantan/regex/joda/time/package.scala
+++ b/joda-time/src/main/scala/kantan/regex/joda/time/package.scala
@@ -19,7 +19,7 @@ package joda
 
 import kantan.codecs.export.Exported
 import kantan.codecs.strings.StringDecoder
-import kantan.codecs.strings.joda.time._
+import kantan.codecs.strings.joda.time.{JodaTimeDecoderCompanion, ToFormatLiteral}
 import org.joda.time.{DateTime, LocalDate, LocalDateTime, LocalTime}
 
 /** Declares [[kantan.regex.GroupDecoder]] instances joda-time types.
@@ -29,7 +29,7 @@ import org.joda.time.{DateTime, LocalDate, LocalDateTime, LocalTime}
   * brings both the instance creation and default instances in scope. Without this type trickery, custom instances
   * and default ones would always clash.
   */
-package object time extends JodaTimeDecoderCompanion[Option[String], DecodeError, codecs.type] {
+package object time extends JodaTimeDecoderCompanion[Option[String], DecodeError, codecs.type] with ToFormatLiteral {
 
   override def decoderFrom[D](d: StringDecoder[D]) = codecs.fromString(d)
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,5 +1,5 @@
 object Versions {
-  val contextual   = "1.0.1"
+  val contextual   = "1.1.0"
   val kantanCodecs = "0.3.1-SNAPSHOT"
   val scalatest    = "3.0.3"
 }


### PR DESCRIPTION
Fixes #72.

Fixes #71, since we needed to upgrade the contextual version to not have conflicts.